### PR TITLE
accessibility crash

### DIFF
--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
@@ -77,6 +77,7 @@ public class OverlayService extends Service implements View.OnTouchListener {
             if (windowManager != null) {
                 windowManager.removeView(flutterView);
                 windowManager = null;
+                flutterView.detachFromFlutterEngine();
                 stopSelf();
             }
             isRunning = false;


### PR DESCRIPTION
In version 3.3, when the accessibility service is enabled, closing the floating window must unbind the engine. Otherwise, opening the floating window again when the floating window route is not in the root directory will cause the program to crash.