### PR TITLE
Added instructions for android 14 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,21 @@ dependencies:
 ### Android
 
 You'll need to add the `SYSTEM_ALERT_WINDOW` permission and `OverlayService` to your Android Manifest.
+Replace `explanation_for_special_use` with your custom explanation.
 
 ```XML
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application>
         ...
-        <service android:name="flutter.overlay.window.flutter_overlay_window.OverlayService" android:exported="false" />
+        <service android:name="flutter.overlay.window.flutter_overlay_window.OverlayService" 
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="explanation_for_special_use"/>
+        </service>
     </application>
 ```
 


### PR DESCRIPTION
I updated the readme with instructions on making this plugin work with Android 14 devices according to instructions from [here](https://developer.android.com/about/versions/14/changes/fgs-types-required).