### PR TITLE
Feature: drag threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ void overlayMain() {
   ///
   /// `enableDrag` to enable/disable dragging the overlay over the screen and default is "false"
   ///
+  /// `dragThreshold` to determine how easy it is to start dragging the overlay and default is 5 (device independant pixels)
+  ///
   /// `positionGravity` the overlay postion after drag and default is [PositionGravity.none]
   ///
   /// `startPosition` the overlay start position and default is null

--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/FlutterOverlayWindowPlugin.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/FlutterOverlayWindowPlugin.java
@@ -86,6 +86,7 @@ public class FlutterOverlayWindowPlugin implements
             String overlayContent = call.argument("overlayContent");
             String notificationVisibility = call.argument("notificationVisibility");
             boolean enableDrag = call.argument("enableDrag");
+            Integer dragThreshold = call.argument("dragThreshold");
             String positionGravity = call.argument("positionGravity");
             Map<String, Integer> startPosition = call.argument("startPosition");
             int startX = startPosition != null ? startPosition.getOrDefault("x", OverlayConstants.DEFAULT_XY) : OverlayConstants.DEFAULT_XY;
@@ -95,6 +96,7 @@ public class FlutterOverlayWindowPlugin implements
             WindowSetup.width = width != null ? width : -1;
             WindowSetup.height = height != null ? height : -1;
             WindowSetup.enableDrag = enableDrag;
+            WindowSetup.dragThreshold = dragThreshold;
             WindowSetup.setGravityFromAlignment(alignment != null ? alignment : "center");
             WindowSetup.setFlag(flag != null ? flag : "flagNotFocusable");
             WindowSetup.overlayTitle = overlayTitle;

--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
@@ -387,7 +387,7 @@ public class OverlayService extends Service implements View.OnTouchListener {
                 case MotionEvent.ACTION_MOVE:
                     float dx = event.getRawX() - lastX;
                     float dy = event.getRawY() - lastY;
-                    if (!dragging && dx * dx + dy * dy < 25) {
+                    if (!dragging && dx * dx + dy * dy < Math.pow(dpToPx(WindowSetup.dragThreshold), 2)) {
                         return false;
                     }
                     lastX = event.getRawX();

--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/WindowSetup.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/WindowSetup.java
@@ -20,6 +20,7 @@ public abstract class WindowSetup {
     static String positionGravity = "none";
     static int notificationVisibility = NotificationCompat.VISIBILITY_PRIVATE;
     static boolean enableDrag = false;
+    static int dragThreshold = 5;
 
 
     static void setNotificationVisibility(String name) {

--- a/lib/src/overlay_window.dart
+++ b/lib/src/overlay_window.dart
@@ -36,6 +36,8 @@ class FlutterOverlayWindow {
   ///
   /// `enableDrag` to enable/disable dragging the overlay over the screen and default is "false"
   ///
+  /// `dragThreshold` to determine how easy it is to start dragging the overlay and default is 5 (device independant pixels)
+  ///
   /// `positionGravity` the overlay postion after drag and default is [PositionGravity.none]
   ///
   /// `startPosition` the overlay start position and default is null

--- a/lib/src/overlay_window.dart
+++ b/lib/src/overlay_window.dart
@@ -48,6 +48,7 @@ class FlutterOverlayWindow {
     String overlayTitle = "overlay activated",
     String? overlayContent,
     bool enableDrag = false,
+    int dragThreshold = 5,
     PositionGravity positionGravity = PositionGravity.none,
     OverlayPosition? startPosition,
   }) async {
@@ -61,6 +62,7 @@ class FlutterOverlayWindow {
         "overlayTitle": overlayTitle,
         "overlayContent": overlayContent,
         "enableDrag": enableDrag,
+        "dragThreshold": dragThreshold,
         "notificationVisibility": visibility.name,
         "positionGravity": positionGravity.name,
         "startPosition": startPosition?.toMap(),


### PR DESCRIPTION
I found finger taps were causing dragging to start unintentionally because the dragging threshold of 5 * 5 was too small. This PR fixes this issue with the following improvements…

1. The default dragging threshold is increased from 5 * 5 physical pixels to 5 * 5 device independent pixels.
2. Modified showOverlay to accept a dragThreshold parameter.