### PR TITLE
Added window insets to respect system bars, especially for full screen overlays

### DIFF
--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/FlutterOverlayWindowPlugin.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/FlutterOverlayWindowPlugin.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import android.provider.Settings;
 import android.service.notification.StatusBarNotification;
 import android.util.Log;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
@@ -90,6 +91,8 @@ public class FlutterOverlayWindowPlugin implements
             Map<String, Integer> startPosition = call.argument("startPosition");
             int startX = startPosition != null ? startPosition.getOrDefault("x", OverlayConstants.DEFAULT_XY) : OverlayConstants.DEFAULT_XY;
             int startY = startPosition != null ? startPosition.getOrDefault("y", OverlayConstants.DEFAULT_XY) : OverlayConstants.DEFAULT_XY;
+            Integer windowInsetsInteger = call.argument("windowInsets");
+            int windowInsets = windowInsetsInteger != null ? windowInsetsInteger : ~WindowInsets.Type.ime();
 
 
             WindowSetup.width = width != null ? width : -1;
@@ -100,6 +103,7 @@ public class FlutterOverlayWindowPlugin implements
             WindowSetup.overlayTitle = overlayTitle;
             WindowSetup.overlayContent = overlayContent == null ? "" : overlayContent;
             WindowSetup.positionGravity = positionGravity;
+            WindowSetup.windowInsets = windowInsets;
             WindowSetup.setNotificationVisibility(notificationVisibility);
 
             final Intent intent = new Intent(context, OverlayService.class);
@@ -109,9 +113,6 @@ public class FlutterOverlayWindowPlugin implements
             intent.putExtra("startY", startY);
             context.startService(intent);
             result.success(null);
-        } else if (call.method.equals("isOverlayActive")) {
-            result.success(OverlayService.isRunning);
-            return;
         } else if (call.method.equals("isOverlayActive")) {
             result.success(OverlayService.isRunning);
             return;

--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayConstants.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayConstants.java
@@ -9,4 +9,6 @@ final public class OverlayConstants {
     static final String CHANNEL_ID = "Overlay Channel";
     static final int NOTIFICATION_ID = 4579;
     static final int DEFAULT_XY = -6;
+    static final int MATCH_PARENT = -1;
+    static final int FULL_COVER = -1999;
 }

--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/WindowSetup.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/WindowSetup.java
@@ -2,6 +2,7 @@ package flutter.overlay.window.flutter_overlay_window;
 
 
 import android.view.Gravity;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 
 import androidx.core.app.NotificationCompat;
@@ -20,6 +21,7 @@ public abstract class WindowSetup {
     static String positionGravity = "none";
     static int notificationVisibility = NotificationCompat.VISIBILITY_PRIVATE;
     static boolean enableDrag = false;
+    static int windowInsets = WindowInsets.Type.systemBars();
 
 
     static void setNotificationVisibility(String name) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_overlay_window_example/home_page.dart';
+import 'package:flutter_overlay_window_example/overlays/fullscreen_overlay.dart';
 import 'package:flutter_overlay_window_example/overlays/true_caller_overlay.dart';
 
 void main() {
@@ -14,6 +15,7 @@ void overlayMain() {
     const MaterialApp(
       debugShowCheckedModeBanner: false,
       home: TrueCallerOverlay(),
+      // home: FullscreenOverlay(),  /// Uncomment to test FullscreenOverlay
     ),
   );
 }

--- a/example/lib/overlays/fullscreen_overlay.dart
+++ b/example/lib/overlays/fullscreen_overlay.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_overlay_window/flutter_overlay_window.dart';
+
+class FullscreenOverlay extends StatelessWidget {
+  const FullscreenOverlay({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.black,
+      child: Padding(
+        padding: const EdgeInsets.all(5.0),
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.white, width: 3),
+          ),
+          child: const Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  'Overlay With White Border',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 24,
+                  ),
+                ),
+                ElevatedButton(
+                    onPressed: FlutterOverlayWindow.closeOverlay,
+                    child: Text(
+                      'Close',
+                    ))
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -100,7 +100,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.5"
+    version: "0.5.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -110,26 +110,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -166,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   multiavatar:
     dependency: "direct main"
     description:
@@ -291,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -320,5 +320,5 @@ packages:
     source: hosted
     version: "14.3.1"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/overlay_config.dart
+++ b/lib/src/overlay_config.dart
@@ -78,3 +78,73 @@ class WindowSize {
   /// even the statusbar and the navigationbar
   static const int fullCover = -1999;
 }
+
+/// Class that matches closely to native Android WindowInsets.Type. 
+/// You can select any combination of insets to be applied to the overlay window.
+class WindowInsetsType {
+  static const int _first = 1 << 0;
+  static const int statusBars = _first;
+  static const int navigationBars = 1 << 1;
+  static const int captionBar = 1 << 2;
+  static const int ime = 1 << 3;
+  static const int systemGestures = 1 << 4;
+  static const int mandatorySystemGestures = 1 << 5;
+  static const int tappableElement = 1 << 6;
+  static const int displayCutout = 1 << 7;
+  static const int windowDecor = 1 << 8;
+  static const int systemOverlays = 1 << 9;
+  static const int size = 10;
+  static const int defaultVisible = ~ime;
+
+  // Private constructor to prevent instantiation
+  WindowInsetsType._();
+  static String typeToString(int types) {
+    final result = StringBuffer();
+    if ((types & statusBars) != 0) {
+      result.write('statusBars ');
+    }
+    if ((types & navigationBars) != 0) {
+      result.write('navigationBars ');
+    }
+    if ((types & captionBar) != 0) {
+      result.write('captionBar ');
+    }
+    if ((types & ime) != 0) {
+      result.write('ime ');
+    }
+    if ((types & systemGestures) != 0) {
+      result.write('systemGestures ');
+    }
+    if ((types & mandatorySystemGestures) != 0) {
+      result.write('mandatorySystemGestures ');
+    }
+    if ((types & tappableElement) != 0) {
+      result.write('tappableElement ');
+    }
+    if ((types & displayCutout) != 0) {
+      result.write('displayCutout ');
+    }
+    if ((types & windowDecor) != 0) {
+      result.write('windowDecor ');
+    }
+    if ((types & systemOverlays) != 0) {
+      result.write('systemOverlays ');
+    }
+    if (result.isNotEmpty) {
+      // Remove trailing space
+      return result.toString().trimRight();
+    }
+    return result.toString();
+  }
+
+  /// Returns all system bars. Includes [statusBars], [captionBar] as well as
+  /// [navigationBars], [systemOverlays], but not [ime].
+  static int getSystemBars() {
+    return statusBars | navigationBars | captionBar | systemOverlays;
+  }
+
+  /// Returns all inset types combined.
+  static int all() {
+    return 0xFFFFFFFF;
+  }
+}

--- a/lib/src/overlay_window.dart
+++ b/lib/src/overlay_window.dart
@@ -50,6 +50,7 @@ class FlutterOverlayWindow {
     bool enableDrag = false,
     PositionGravity positionGravity = PositionGravity.none,
     OverlayPosition? startPosition,
+    int windowInsets = WindowInsetsType.defaultVisible,
   }) async {
     await _channel.invokeMethod(
       'showOverlay',
@@ -64,6 +65,7 @@ class FlutterOverlayWindow {
         "notificationVisibility": visibility.name,
         "positionGravity": positionGravity.name,
         "startPosition": startPosition?.toMap(),
+        "windowInsets": windowInsets,
       },
     );
   }

--- a/lib/src/overlay_window.dart
+++ b/lib/src/overlay_window.dart
@@ -119,10 +119,19 @@ class FlutterOverlayWindow {
   }
 
   /// Update the overlay size in the screen
+  ///
+  /// `width` the overlay width
+  /// `height` the overlay height
+  /// `enableDrag` to enable/disable dragging the overlay
+  /// `windowInsets` the overlay insets, optional. You can combine the flags of
+  /// WindowInsetsType with the binary | operator. If not specified, the insets
+  /// will not be updated and remain at previous value.
+  /// `return` true if the size updated successfully
   static Future<bool?> resizeOverlay(
     int width,
     int height,
     bool enableDrag,
+    {int windowInsets = -1}
   ) async {
     final bool? _res = await _overlayChannel.invokeMethod<bool?>(
       'resizeOverlay',
@@ -130,6 +139,7 @@ class FlutterOverlayWindow {
         'width': width,
         'height': height,
         'enableDrag': enableDrag,
+        'windowInsets': windowInsets
       },
     );
     return _res;


### PR DESCRIPTION
Introduced Window Insets, where user of library can select which insets (statusbar, navigationbar etc) should be respected by the overlay. This is especially needed for full screen overlays, which tended to take up more than the whole screen (overflow out of bounds).

I also did a tiny bit of refactoring around setting the initial position and moving the overlay, which seemed to be buggy.