### PR TITLE
add openMainApp method to bring the main app to foreground from overlay

### DIFF
--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
@@ -141,9 +141,11 @@ public class OverlayService extends Service implements View.OnTouchListener {
                 boolean enableDrag = call.argument("enableDrag");
                 resizeOverlay(width, height, enableDrag, result);
             } else if (call.method.equals("openMainApp")) {
-                intent.setClassName("com.hertzaz.driver", "com.hertzaz.driver.MainActivity");
-                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                startActivity(intent);
+                Intent launchIntent = getPackageManager().getLaunchIntentForPackage(getPackageName());
+                if (launchIntent != null) {
+                    launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                    startActivity(launchIntent);
+                }
             }
         });
         overlayMessageChannel.setMessageHandler((message, reply) -> {

--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
@@ -141,10 +141,9 @@ public class OverlayService extends Service implements View.OnTouchListener {
                 boolean enableDrag = call.argument("enableDrag");
                 resizeOverlay(width, height, enableDrag, result);
             } else if (call.method.equals("openMainApp")) {
-                Intent newIntent = new Intent();
-                newIntent.setClassName("com.hertzaz.hertz_driver", "com.hertzaz.hertz_driver.MainActivity");
-                newIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                startActivity(newIntent);
+                intent.setClassName("com.hertzaz.hertz_driver", "com.hertzaz.hertz_driver.MainActivity");
+                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(intent);
             }
         });
         overlayMessageChannel.setMessageHandler((message, reply) -> {

--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
@@ -140,6 +140,11 @@ public class OverlayService extends Service implements View.OnTouchListener {
                 int height = call.argument("height");
                 boolean enableDrag = call.argument("enableDrag");
                 resizeOverlay(width, height, enableDrag, result);
+            } else if (call.method.equals("openMainApp")) {
+                Intent newIntent = new Intent();
+                newIntent.setClassName("com.hertzaz.hertz_driver", "com.hertzaz.hertz_driver.MainActivity");
+                newIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivity(newIntent);
             }
         });
         overlayMessageChannel.setMessageHandler((message, reply) -> {

--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
@@ -141,7 +141,7 @@ public class OverlayService extends Service implements View.OnTouchListener {
                 boolean enableDrag = call.argument("enableDrag");
                 resizeOverlay(width, height, enableDrag, result);
             } else if (call.method.equals("openMainApp")) {
-                intent.setClassName("com.hertzaz.hertz_driver", "com.hertzaz.hertz_driver.MainActivity");
+                intent.setClassName("com.hertzaz.driver", "com.hertzaz.driver.MainActivity");
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 startActivity(intent);
             }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -100,7 +100,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.5"
+    version: "0.5.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -110,26 +110,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -166,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   multiavatar:
     dependency: "direct main"
     description:
@@ -291,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -320,5 +320,5 @@ packages:
     source: hosted
     version: "14.3.1"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/overlay_window.dart
+++ b/lib/src/overlay_window.dart
@@ -162,6 +162,11 @@ class FlutterOverlayWindow {
     return _res ?? false;
   }
 
+  static Future<bool?> openMainApp() async {
+    final bool? _res = await _overlayChannel.invokeMethod<bool?>('openMainApp');
+    return _res;
+  }
+
   /// Dispose overlay stream
   static void disposeOverlayListener() {
     _controller.close();


### PR DESCRIPTION
Adds a new openMainApp method that allows the overlay window to programmatically bring the host application back to the foreground